### PR TITLE
Fix reopening of closed issues

### DIFF
--- a/main.py
+++ b/main.py
@@ -153,7 +153,7 @@ def main():
     repo_ref = os.getenv("GITHUB_REF_NAME")
     server_url = os.getenv("GITHUB_SERVER_URL")
 
-    repo_issues = gh_repo.get_issues()
+    repo_issues = gh_repo.get_issues(state="all")
     for issue_ref, issues in unique_closed_issues.items():
         locations = [(i.filename, i.lineno) for i in issues]
         files_str = "\n".join(


### PR DESCRIPTION
#21 changed the upstream-issue-notifier to check for closed issues to avoid creating new duplicate notification issues if the same issue was previously closed. However, this fix did not work as intended, and the upstream issue notifier is still creating duplicate issues.

This is because when the upstream issue notifier obtains the host repository's issues, the `get_issues()` call doesn't specify issue state (open, closed, all) and used the default API behavior, which is [currently documented](https://pygithub.readthedocs.io/en/latest/github_objects/Repository.html#github.Repository.Repository.get_issues) as only providing **open** issues. 

This fix specifies the `get_issues()` call to take **all** issues on the host repository and therefore check the closed issues and fix this behavior.